### PR TITLE
Use latest pyodide release

### DIFF
--- a/pyconfig.toml
+++ b/pyconfig.toml
@@ -1,1 +1,2 @@
 packages = ["libcst"]
+interpreter = "https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.mjs"


### PR DESCRIPTION
This release contains libcst 1.3.1 instead of 0.3.x. Hope it works